### PR TITLE
Adds ability to define a source for atlantis.yaml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-*
-!docker-entrypoint.sh
-!atlantis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 # The runatlantis/atlantis-base is created by docker-base/Dockerfile.
+FROM golang:1.12 as builder
+WORKDIR /go/src/github.com/runatlantis/atlantis
+COPY . /go/src/github.com/runatlantis/atlantis
+RUN CGO_ENABLED=0 go build -o atlantis main.go
 FROM runatlantis/atlantis-base:v3.0
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
@@ -20,7 +24,7 @@ RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 ${DEFAULT_TERRAFORM_VERSIO
     ln -s /usr/local/bin/tf/versions/${DEFAULT_TERRAFORM_VERSION}/terraform /usr/local/bin/terraform
 
 # copy binary
-COPY atlantis /usr/local/bin/atlantis
+COPY --from=builder /go/src/github.com/runatlantis/atlantis/atlantis /usr/local/bin/atlantis
 
 # copy docker entrypoint
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -45,6 +45,7 @@ const (
 	BitbucketUserFlag          = "bitbucket-user"
 	BitbucketWebhookSecretFlag = "bitbucket-webhook-secret"
 	ConfigFlag                 = "config"
+	ConfigSourceFlag           = "config-source"
 	CheckoutStrategyFlag       = "checkout-strategy"
 	DataDirFlag                = "data-dir"
 	DefaultTFVersionFlag       = "default-tf-version"
@@ -107,6 +108,10 @@ var stringFlags = []stringFlag{
 	{
 		name:        ConfigFlag,
 		description: "Path to config file. All flags can be set in a YAML config file instead.",
+	},
+	{
+		name:        ConfigSourceFlag,
+		description: "Specifies a source to get the atlantis configuration file from. Requires the --allow-repo-config flag to be set.",
 	},
 	{
 		name: CheckoutStrategyFlag,
@@ -394,6 +399,7 @@ func (s *ServerCmd) run() error {
 		AtlantisURLFlag:      AtlantisURLFlag,
 		AtlantisVersion:      s.AtlantisVersion,
 		DefaultTFVersionFlag: DefaultTFVersionFlag,
+		ConfigSource:         ConfigSourceFlag,
 	})
 	if err != nil {
 		return errors.Wrap(err, "initializing server")

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const atlantisVersion = "0.6.0"
+const atlantisVersion = "0.7.0"
 
 func main() {
 	v := viper.New()

--- a/server/fetchers/fetcher.go
+++ b/server/fetchers/fetcher.go
@@ -1,0 +1,10 @@
+package fetchers
+
+type FetcherConfig struct {
+	ConfigType   ConfigSourceType
+	GithubConfig *GithubFetcherConfig
+}
+
+type Fetcher interface {
+	FetchConfig() (string, error)
+}

--- a/server/fetchers/github_fetcher.go
+++ b/server/fetchers/github_fetcher.go
@@ -1,0 +1,118 @@
+package fetchers
+
+import (
+	"context"
+	"encoding/base64"
+	"net/url"
+	"strings"
+
+	"github.com/google/go-github/github"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+)
+
+type GithubFetcherConfig struct {
+	Repo  string
+	Owner string
+	Path  string
+	Query string
+	Token string
+}
+
+func (c *GithubFetcherConfig) FetchConfig() (string, error) {
+	ctx := context.Background()
+
+	// Get an authenticated github client
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: c.Token},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+	client := github.NewClient(tc)
+
+	// construct the get options from the query segment of the fetcher config
+	opt := github.RepositoryContentGetOptions{Ref: c.Query}
+
+	// Get the actual file contents.
+	// We are only interested in a file content, not the result of a directory listing.
+	fileContent, _, _, err := client.Repositories.GetContents(ctx, c.Owner, c.Repo, c.Path, &opt)
+	if err != nil {
+		return "", errors.Wrap(err, "could not fetch content")
+	}
+
+	// Bae64 decode the response's body.
+	configString, err := decodeContent(*fileContent.Content)
+	if err != nil {
+		return "", errors.New("error decoding config file content")
+	}
+
+	// We got config!
+	return configString, nil
+}
+
+func ParseGithubReference(c *GithubFetcherConfig, remoteReference string, token string) error {
+	u, err := url.Parse(remoteReference)
+	if err != nil {
+		return errors.Wrap(err, "remote reference syntax error")
+	}
+
+	// Parse the path part of the URL.
+	// The most minimal Remote Reference for github would look like this:
+	// `http://github.com/owner/repo/atlantis.yaml`
+	//
+	// When it is parsed using url.Parse(), the Path() function returns this
+	// `/owner/repo/atlantis.yaml`
+	//
+	// If we split it by `/`, then the first element in the slice is going to be empty, given that the first character
+	// is `/`, and the minimum number of elements we should get is 4, that includes the owner, the repo, and the
+	// atlantis file name.
+	p := strings.Split(u.Path, "/")
+	if len(p) < 4 {
+		return errors.New("remote reference incomplete")
+	}
+
+	c.Token = token
+	c.Owner = p[1]
+	c.Repo = p[2]
+	c.Path = strings.Join(p[3:], "/")
+
+	// Pick the first ref, if it exists. Users should be passing more than one ref anyway.
+	refs, ok := u.Query()["ref"]
+	if ok {
+		c.Query = refs[0]
+	}
+
+	// Validate the fetcher config before moving forward
+	return validateGithubFetcherConfig(c)
+}
+
+func validateGithubFetcherConfig(config *GithubFetcherConfig) error {
+	// GithubFetcherConfig.Query field can be empty, so we don't validate it here.
+
+	if config.Owner == "" {
+		return errors.New("github owner is not set")
+	}
+
+	if config.Repo == "" {
+		return errors.New("github repo is not set")
+	}
+
+	if config.Path == "" {
+		return errors.New("github path is not set")
+	}
+
+	if config.Token == "" {
+		return errors.New("github token is not set")
+	}
+
+	return nil
+}
+
+func decodeContent(content interface{}) (string, error) {
+	decodedContent, err := base64.StdEncoding.DecodeString(content.(string))
+	if err != nil {
+		err = errors.New("could not decode file content")
+		return "", err
+	}
+
+	return string(decodedContent), nil
+}

--- a/server/fetchers/github_fetcher_test.go
+++ b/server/fetchers/github_fetcher_test.go
@@ -1,0 +1,135 @@
+package fetchers
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+// @TODO test GithubFetcherConfig
+func TestGithubFetcherConfig_FetchConfig(t *testing.T) {
+
+}
+
+func TestParseRemoteReference(t *testing.T) {
+	testCases := []struct {
+		Name      string
+		Reference string
+		Token     string
+		Owner     string
+		Repo      string
+		Query     string
+		Error     error
+	}{
+		{
+			Name:      "Normal Scenario",
+			Reference: "https://github.com/runatlantis/atlantis/atlantis.yaml?ref=master",
+			Token:     "my-token",
+			Owner:     "runatlantis",
+			Repo:      "atlantis",
+			Query:     "master",
+			Error:     nil,
+		},
+		{
+			Name:      "Empty Token",
+			Reference: "https://github.com/runatlantis/atlantis/atlantis.yaml?ref=master",
+			Token:     "",
+			Owner:     "runatlantis",
+			Repo:      "atlantis",
+			Query:     "master",
+			Error:     errors.New("github token is not set"),
+		},
+		{
+			Name:      "Empty Owner",
+			Reference: "https://github.com//atlantis/atlantis.yaml?ref=master",
+			Token:     "my-token",
+			Owner:     "runatlantis",
+			Repo:      "atlantis",
+			Query:     "master",
+			Error:     errors.New("github owner is not set"),
+		},
+		{
+			Name:      "Empty Repo",
+			Reference: "https://github.com/runatlantis//atlantis.yaml?ref=master",
+			Token:     "my-token",
+			Owner:     "runatlantis",
+			Repo:      "atlantis",
+			Query:     "master",
+			Error:     errors.New("github repo is not set"),
+		},
+		{
+			Name:      "Empty Path",
+			Reference: "https://github.com/runatlantis/atlantis/?ref=master",
+			Token:     "my-token",
+			Owner:     "runatlantis",
+			Repo:      "atlantis",
+			Query:     "master",
+			Error:     errors.New("github path is not set"),
+		},
+		{
+			Name:      "Incomplete Remote Reference",
+			Reference: "https://github.com/runatlantis/atlantis",
+			Token:     "my-token",
+			Owner:     "runatlantis",
+			Repo:      "atlantis",
+			Query:     "master",
+			Error:     errors.New("remote reference incomplete"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			config := GithubFetcherConfig{}
+			err := ParseGithubReference(&config, tc.Reference, tc.Token)
+			if tc.Error == nil {
+				Equals(t, tc.Token, config.Token)
+				Equals(t, tc.Owner, config.Owner)
+				Equals(t, tc.Repo, config.Repo)
+				Equals(t, tc.Query, config.Query)
+				Equals(t, nil, err)
+			} else {
+				ErrContains(t, tc.Error.Error(), err)
+			}
+		})
+	}
+}
+
+func TestDecodeContent(t *testing.T) {
+	testCases := []struct {
+		Name          string
+		EncodedString string
+		DecodedString string
+		Error         error
+	}{
+		{
+			Name:          "Normal Scenario",
+			EncodedString: "SGVsbG8sIHdvcmxkIQ==",
+			DecodedString: "Hello, world!",
+			Error:         nil,
+		},
+		{
+			Name:          "Empty String",
+			EncodedString: "",
+			DecodedString: "",
+			Error:         nil,
+		},
+		{
+			Name:          "Corrupted String",
+			EncodedString: "sdsdsd",
+			DecodedString: "",
+			Error:         errors.New("could not decode file content"),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			content, err := decodeContent(tc.EncodedString)
+			if tc.Error == nil {
+				Equals(t, nil, err)
+				Equals(t, tc.DecodedString, content)
+			} else {
+				ErrContains(t, tc.Error.Error(), err)
+			}
+		})
+	}
+}

--- a/server/fetchers/parser.go
+++ b/server/fetchers/parser.go
@@ -1,0 +1,36 @@
+package fetchers
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/pkg/errors"
+)
+
+type ConfigSourceType int
+
+const (
+	Github ConfigSourceType = iota
+	// Other source types should be added later here when their fetchers are implemented, like:
+	// S3
+	// Bitbucket
+	// etc.
+)
+
+type Parser interface {
+	ParseConnection(remoteReference string, token string) error
+}
+
+func GetType(remoteReference string) (ConfigSourceType, error) {
+	u, err := url.Parse(remoteReference)
+
+	if err != nil {
+		return 0, errors.Wrap(err, "")
+	}
+	switch {
+	case u.Hostname() == "github.com":
+		return Github, nil
+	default:
+		return 0, errors.New(fmt.Sprintf("unknown source in remote reference: %s", remoteReference))
+	}
+}

--- a/server/fetchers/parser_test.go
+++ b/server/fetchers/parser_test.go
@@ -1,0 +1,61 @@
+package fetchers
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/runatlantis/atlantis/testing"
+)
+
+func TestGetType(t *testing.T) {
+	testCases := []struct {
+		Name       string
+		Reference  string
+		SourceType ConfigSourceType
+		Error      error
+	}{
+		{
+			Name:       "Github HTTPS",
+			Reference:  "https://github.com/runatlantis/atlantis",
+			SourceType: Github,
+			Error:      nil,
+		},
+		{
+			Name:       "Github HTTP",
+			Reference:  "http://github.com/runatlantis/atlantis",
+			SourceType: Github,
+			Error:      nil,
+		},
+		{
+			Name:       "Unknown Hostname",
+			Reference:  "https://example.com/runatlantis/atlantis",
+			SourceType: 0,
+			Error:      errors.New("unknown source in remote reference: https://example.com/runatlantis/atlantis"),
+		},
+		{
+			Name:       "Random String",
+			Reference:  "some-random-string",
+			SourceType: 0,
+			Error:      errors.New("unknown source in remote reference: some-random-string"),
+		},
+		{
+			Name:       "Empty String",
+			Reference:  "",
+			SourceType: 0,
+			Error:      errors.New("unknown source in remote reference: "),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Reference, func(t *testing.T) {
+			sourceType, err := GetType(tc.Reference)
+
+			if tc.Error == nil {
+				Equals(t, nil, err)
+			} else {
+				ErrContains(t, tc.Error.Error(), err)
+			}
+			Equals(t, tc.SourceType, sourceType)
+		})
+	}
+}

--- a/server/user_config.go
+++ b/server/user_config.go
@@ -1,6 +1,8 @@
 package server
 
-import "github.com/runatlantis/atlantis/server/logging"
+import (
+	"github.com/runatlantis/atlantis/server/logging"
+)
 
 // UserConfig holds config values passed in by the user.
 // The mapstructure tags correspond to flags in cmd/server.go and are used when
@@ -15,6 +17,7 @@ type UserConfig struct {
 	BitbucketUser          string `mapstructure:"bitbucket-user"`
 	BitbucketWebhookSecret string `mapstructure:"bitbucket-webhook-secret"`
 	CheckoutStrategy       string `mapstructure:"checkout-strategy"`
+	ConfigSource           string `mapstructure:"config-source"`
 	DataDir                string `mapstructure:"data-dir"`
 	GithubHostname         string `mapstructure:"gh-hostname"`
 	GithubToken            string `mapstructure:"gh-token"`


### PR DESCRIPTION
Atlantis currently looks for the global atlantis.yaml configuration file in the branch it pulls down from the PR. This PR adds another flag, `--config-source`, that is passed to the atlantis server, and defines the source of the atlantis.yaml file. This now supports only Github, but can be extended to support other sources in the future,(e.g., Bitbucket, S3, Google Storage, etc.).

To specify a file within a github repository in a given branch you need to add this new flag in the following format:

`--config-source="https://github.com/<owner>/<repo>/[path]atlantis.yaml?[ref=<branch>]"`

Replace <owner>, <repo>, and <branch> with the github username, github repository, and branch name respectively. `[path]` is optional though.

The `--allow-repo-config` parameter is still required for this feature to work. In the future, `--allow-repo-config` can be deprecated and its behaviour can be incorporated in the `--config-source` flag.