### PR TITLE
Bump Terraform from v0.12.0 to v0.12.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM runatlantis/atlantis-base:v3.0
 LABEL authors="Anubhav Mishra, Luke Kysow"
 
 # install terraform binaries
-ENV DEFAULT_TERRAFORM_VERSION=0.12.0
+ENV DEFAULT_TERRAFORM_VERSION=0.12.1
 
 # In the official Atlantis image we only have the latest of each Terrafrom version.
 RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 0.11.14 ${DEFAULT_TERRAFORM_VERSION}" && \


### PR DESCRIPTION
There are a number of bugfixes in this release but most importantly this
release fixes a double terraform init issue we were having (PR 21439)
that prevented atlantis from working correctly.