### PR TITLE
Update terraform version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,11 @@ ARG TARGETPLATFORM
 
 # install terraform binaries
 # renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp
-ENV DEFAULT_TERRAFORM_VERSION=1.3.7
+ENV DEFAULT_TERRAFORM_VERSION=1.4.6
 
 # In the official Atlantis image we only have the latest of each Terraform version.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN AVAILABLE_TERRAFORM_VERSIONS="0.8.8 0.9.11 0.10.8 0.11.14 0.11.15 0.12.29 0.12.31 0.13.2 0.13.7 1.0.11 1.1.9 1.2.9 ${DEFAULT_TERRAFORM_VERSION}" && \
+RUN AVAILABLE_TERRAFORM_VERSIONS="0.11.15 0.12.31 0.13.7 0.14.9 0.15.5 1.0.10 1.1.9 1.2.9 1.3.7 ${DEFAULT_TERRAFORM_VERSION}" && \
     case "${TARGETPLATFORM}" in \
         "linux/amd64") TERRAFORM_ARCH=amd64 ;; \
         "linux/arm64") TERRAFORM_ARCH=arm64 ;; \


### PR DESCRIPTION
Removed versions that we aren't using, and the last minor release for each major release.

```
$ cat atlantis.yaml|grep terraform_version |uniq|sort
    terraform_version: v0.11.15
    terraform_version: v0.13.7
    terraform_version: v1.3.7
```
