### PR TITLE
Revert "Remove default terraform version"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,11 @@ ARG TARGETPLATFORM
 
 # install terraform binaries
 # renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp
+ENV DEFAULT_TERRAFORM_VERSION=1.4.6
 
 # In the official Atlantis image we only have the latest of each Terraform version.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN AVAILABLE_TERRAFORM_VERSIONS="0.11.15 0.12.31 0.13.7 0.14.9 0.15.5 1.0.10 1.1.9 1.2.9 1.3.7 1.4.6" && \
+RUN AVAILABLE_TERRAFORM_VERSIONS="0.11.15 0.12.31 0.13.7 0.14.9 0.15.5 1.0.10 1.1.9 1.2.9 1.3.7 ${DEFAULT_TERRAFORM_VERSION}" && \
     case "${TARGETPLATFORM}" in \
         "linux/amd64") TERRAFORM_ARCH=amd64 ;; \
         "linux/arm64") TERRAFORM_ARCH=arm64 ;; \
@@ -48,10 +49,11 @@ RUN AVAILABLE_TERRAFORM_VERSIONS="0.11.15 0.12.31 0.13.7 0.14.9 0.15.5 1.0.10 1.
         ln -s "/usr/local/bin/tf/versions/${VERSION}/terraform" "/usr/local/bin/terraform${VERSION}" && \
         rm "terraform_${VERSION}_linux_${TERRAFORM_ARCH}.zip" && \
         rm "terraform_${VERSION}_SHA256SUMS"; \
-    done
+    done && \
+    ln -s "/usr/local/bin/tf/versions/${DEFAULT_TERRAFORM_VERSION}/terraform" /usr/local/bin/terraform
 
 # renovate: datasource=github-releases depName=open-policy-agent/conftest
-ENV DEFAULT_CONFTEST_VERSION=0.42.1
+ENV DEFAULT_CONFTEST_VERSION=0.38.0
 
 RUN AVAILABLE_CONFTEST_VERSIONS="${DEFAULT_CONFTEST_VERSION}" && \
     case "${TARGETPLATFORM}" in \


### PR DESCRIPTION
Reverts gocardless/atlantis#73

Atlantis doesn't boot if there isn't a default Terraform version. However, we should move this variable from the container to the Atlantis configuration so the Utopia terraform consoles don't have a default terraform. That will prevent issues. 