### PR TITLE
Removed default terraform configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,13 +27,9 @@ FROM ${ATLANTIS_BASE}:${ATLANTIS_BASE_TAG_DATE}-${ATLANTIS_BASE_TAG_TYPE} AS bas
 # Get the architecture the image is being built for
 ARG TARGETPLATFORM
 
-# install terraform binaries
-# renovate: datasource=github-releases depName=hashicorp/terraform versioning=hashicorp
-ENV DEFAULT_TERRAFORM_VERSION=1.4.6
-
 # In the official Atlantis image we only have the latest of each Terraform version.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN AVAILABLE_TERRAFORM_VERSIONS="0.11.15 0.12.31 0.13.7 0.14.9 0.15.5 1.0.10 1.1.9 1.2.9 1.3.7 ${DEFAULT_TERRAFORM_VERSION}" && \
+RUN AVAILABLE_TERRAFORM_VERSIONS="0.11.15 0.12.31 0.13.7 0.14.9 0.15.5 1.0.10 1.1.9 1.2.9 1.3.7 1.4.6 1.5.2" && \
     case "${TARGETPLATFORM}" in \
         "linux/amd64") TERRAFORM_ARCH=amd64 ;; \
         "linux/arm64") TERRAFORM_ARCH=arm64 ;; \
@@ -49,11 +45,10 @@ RUN AVAILABLE_TERRAFORM_VERSIONS="0.11.15 0.12.31 0.13.7 0.14.9 0.15.5 1.0.10 1.
         ln -s "/usr/local/bin/tf/versions/${VERSION}/terraform" "/usr/local/bin/terraform${VERSION}" && \
         rm "terraform_${VERSION}_linux_${TERRAFORM_ARCH}.zip" && \
         rm "terraform_${VERSION}_SHA256SUMS"; \
-    done && \
-    ln -s "/usr/local/bin/tf/versions/${DEFAULT_TERRAFORM_VERSION}/terraform" /usr/local/bin/terraform
+    done
 
 # renovate: datasource=github-releases depName=open-policy-agent/conftest
-ENV DEFAULT_CONFTEST_VERSION=0.38.0
+ENV DEFAULT_CONFTEST_VERSION=0.44.1
 
 RUN AVAILABLE_CONFTEST_VERSIONS="${DEFAULT_CONFTEST_VERSION}" && \
     case "${TARGETPLATFORM}" in \


### PR DESCRIPTION
Atlantis server requires a default tf version. However, this setting here also has the side effect of having a default version in utopia terraform. This is not safe, as you might be updating the tf state version by mistake.

Move this setting to the Atlantis runtime config, so we check and run only the relevant terraform version in case of manual intervention. 

