### PR TITLE
INC-5131: APIController: /api/apply pretend PRs have been approved

### DIFF
--- a/server/controllers/api_controller.go
+++ b/server/controllers/api_controller.go
@@ -212,6 +212,16 @@ func (a *APIController) apiParseAndValidate(r *http.Request) (*APIRequest, *comm
 		return nil, nil, http.StatusForbidden, fmt.Errorf("repo not allowlisted")
 	}
 
+	// TODO: Fetch the real status
+	// INC-5131: In the meantime, assume that the PR has been approved
+	fakePullRequestStatus := models.PullReqStatus {
+		// XXX: What do we put in here?
+		ApprovalStatus: models.ApprovalStatus{
+			IsApproved: true,
+		},
+		Mergeable: true,
+	}
+
 	return &request, &command.Context{
 		HeadRepo: baseRepo,
 		Pull: models.PullRequest{
@@ -221,6 +231,7 @@ func (a *APIController) apiParseAndValidate(r *http.Request) (*APIRequest, *comm
 			HeadCommit: request.Ref,
 			BaseRepo:   baseRepo,
 		},
+		PullRequestStatus: fakePullRequestStatus,
 		Scope: a.Scope,
 		Log:   a.Logger,
 	}, http.StatusOK, nil


### PR DESCRIPTION
When a request to apply run is given from the /api/, we don't have enough context regarding if the PR has actually been approved or not.

To work around this, we fake it, and pretend the PR is okay. --
Note, this is _not_ the same code path that is used when the `atlantis apply` comment is posted on a Github PR.

This only applies to runs that are triggered, bypassing the normal GH comment process. This code can be disabled by unsetting ATLANTIS_API_SECRET to disable these APIs.
